### PR TITLE
feat: frontend task with ThemeTrait

### DIFF
--- a/web/modules/custom/server_general/src/ThemeTrait/ElementWrapThemeTrait.php
+++ b/web/modules/custom/server_general/src/ThemeTrait/ElementWrapThemeTrait.php
@@ -546,7 +546,7 @@ trait ElementWrapThemeTrait {
    * @return array
    *   Render array.
    */
-  protected function wrapTextColor(array|string|TranslatableMarkup $element, TextColorEnum $color): array {
+  protected function wrapTextColor(array|string|TranslatableMarkup $element, TextColorEnum $color, TextColorEnum $backgroundColor = null): array {
     if (is_array($element)) {
       $element = $this->filterEmptyElements($element);
     }
@@ -558,6 +558,7 @@ trait ElementWrapThemeTrait {
     return [
       '#theme' => 'server_theme_text_decoration__font_color',
       '#color' => $color->value,
+      '#backgroundColor' => $backgroundColor?->value,
       '#element' => $element,
     ];
   }

--- a/web/modules/custom/server_general/src/ThemeTrait/Enum/TextColorEnum.php
+++ b/web/modules/custom/server_general/src/ThemeTrait/Enum/TextColorEnum.php
@@ -11,4 +11,5 @@ enum TextColorEnum: string {
   case DarkGray = 'dark-gray';
   case Gray = 'gray';
   case LightGray = 'light-gray';
+  case LightGreen = 'light-green';
 }

--- a/web/modules/custom/server_general/src/ThemeTrait/PeopleTeasersThemeTrait.php
+++ b/web/modules/custom/server_general/src/ThemeTrait/PeopleTeasersThemeTrait.php
@@ -56,13 +56,13 @@ trait PeopleTeasersThemeTrait {
    * @return array
    *   The render array.
    */
-  protected function buildElementPersonTeaser(string $image_url, string $alt, string $name, ?string $subtitle = NULL): array {
+  protected function buildElementPersonTeaser(string $image_url, string $alt, string $name, ?string $subtitle = NULL, $role = NULL): array {
     $elements = [];
     $element = [
       '#theme' => 'image',
       '#uri' => $image_url,
       '#alt' => $alt,
-      '#width' => 100,
+      '#width' => 128,
     ];
 
     $elements[] = $this->wrapRoundedCornersFull($element);
@@ -76,6 +76,10 @@ trait PeopleTeasersThemeTrait {
       $element = $this->wrapTextResponsiveFontSize($subtitle, FontSizeEnum::Sm);
       $element = $this->wrapTextCenter($element);
       $inner_elements[] = $this->wrapTextColor($element, TextColorEnum::Gray);
+    }
+
+    if ($role) {
+      $inner_elements[] = $this->wrapTextColor($role, TextColorEnum::Gray, TextColorEnum::LightGreen);
     }
 
     $elements[] = $this->wrapContainerVerticalSpacingTiny($inner_elements, AlignmentEnum::Center);

--- a/web/modules/custom/server_style_guide/server_style_guide.routing.yml
+++ b/web/modules/custom/server_style_guide/server_style_guide.routing.yml
@@ -1,7 +1,7 @@
 server_style_guide.style_guide:
   path: '/style-guide'
   defaults:
-    _controller: '\Drupal\server_style_guide\Controller\StyleGuideController::styleGuidePage'
+    _controller: '\Drupal\server_style_guide\Controller\StyleGuideController::styleGuidePageNew'
     _title: 'Style Guide'
   requirements:
     _permission: 'access content'

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -67,45 +67,26 @@ class StyleGuideController extends ControllerBase {
   use TitleAndLabelsThemeTrait;
   use WebformTrait;
 
+  public function styleGuidePageNew () {
+    $build = [];
 
-  /**
-   * The link generator service.
-   *
-   * @var \Drupal\Core\Utility\LinkGenerator
-   */
-  protected $linkGenerator;
+    $build[] = [
+      '#theme' => 'server_style_guide_wrapper',
+      '#elements' => $this->getAllElementsNew(),
+    ];
 
-  /**
-   * The iFrame URL helper service, used for embedding videos.
-   *
-   * @var \Drupal\media\IFrameUrlHelper
-   */
-  protected $iFrameUrlHelper;
+    $build['#attached']['library'][] = 'server_style_guide/accordion';
 
-  /**
-   * The renderer.
-   *
-   * @var \Drupal\Core\Render\RendererInterface
-   */
-  protected $renderer;
+    return $build;
+  }
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
+  protected function getAllElementsNew() : array {
+    $build = [];
 
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    $instance = parent::create($container);
-    $instance->linkGenerator = $container->get('link_generator');
-    $instance->iFrameUrlHelper = $container->get('media.oembed.iframe_url_helper');
-    $instance->renderer = $container->get('renderer');
-    $instance->entityTypeManager = $container->get('entity_type.manager');
-    return $instance;
+    $element = $this->getPeopleTeasers();
+    $build[] = $this->wrapElementNoContainer($element, 'Element: People teasers');
+
+    return $build;
   }
 
   /**
@@ -277,15 +258,42 @@ class StyleGuideController extends ControllerBase {
       'Smith Allen',
       'David Bowie',
       'Rick Morty',
+      'Maria Smith',
+      'John Johnson',
+      'Sarah Williams',
+      'Michael Brown',
+      'Emily Davis',
+      'James Wilson',
     ];
+
+    $subtitles = [
+      'Chief Executive Officer',
+      'General Director',
+      'Chief Technology Officer',
+      'Senior Developer',
+      'Project Manager',
+      'Lead Designer',
+      'Marketing Director',
+      'Product Owner',
+    ];
+
+    $roles = [
+      'Leadership',
+      'Engineering',
+      'Design',
+      'Marketing',
+      'Product',
+      'Operations',
+    ];
+
     foreach ($names as $key => $name) {
       $items[] = $this->buildElementPersonTeaser(
-        $this->getPlaceholderPersonImage(100),
+        $this->getPlaceholderPersonImage(128),
         'The image alt ' . $name,
         $name,
-        $key === 1 ? 'General Director, and Assistant to The Regional Manager' : NULL,
+        $subtitles[array_rand($subtitles)],
+        $roles[array_rand($roles)],
       );
-
     }
 
     return $this->buildElementPeopleTeasers(

--- a/web/themes/custom/server_theme/package.json
+++ b/web/themes/custom/server_theme/package.json
@@ -1,5 +1,8 @@
 {
-  "scripts": {},
+  "scripts": {
+    "build:css": "postcss src/pcss/style.pcss -o dist/css/style.css",
+    "watch:css": "postcss src/pcss/style.pcss -o dist/css/style.css --watch"
+  },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",
     "autoprefixer": "^10.4.12",

--- a/web/themes/custom/server_theme/server_theme.theme
+++ b/web/themes/custom/server_theme/server_theme.theme
@@ -359,6 +359,7 @@ function server_theme_theme() {
   $info['server_theme_text_decoration__font_color'] = [
     'variables' => [
       'color' => NULL,
+      'backgroundColor' => NULL,
       'element' => [],
     ],
   ];
@@ -520,13 +521,16 @@ function server_theme_theme() {
 function server_theme_preprocess_page(array &$variables) {
   $language = \Drupal::languageManager()->getCurrentLanguage();
 
-  $language_block_config = [
-    'widget' => LanguageDropdownConstants::LANGDROPDOWN_SIMPLE_SELECT,
-    'hide_only_one' => FALSE,
-    'showall' => TRUE,
-    'width' => 'auto',
-    'display' => LanguageDropdownConstants::LANGDROPDOWN_DISPLAY_NATIVE,
-  ];
+  $language_block_config = [];
+  if (\Drupal::moduleHandler()->moduleExists('lang_dropdown')) {
+    $language_block_config = [
+      'widget' => LanguageDropdownConstants::LANGDROPDOWN_SIMPLE_SELECT,
+      'hide_only_one' => FALSE,
+      'showall' => TRUE,
+      'width' => 'auto',
+      'display' => LanguageDropdownConstants::LANGDROPDOWN_DISPLAY_NATIVE,
+    ];
+  }
 
   $messages = !empty($variables['page']['header']['server_theme_messages']) ? $variables['page']['header']['server_theme_messages'] : NULL;
 
@@ -605,7 +609,7 @@ function server_theme_theme_suggestions_page_title_alter(array &$suggestions, ar
  *   Render array.
  */
 function server_theme_prepare_block(string $bid, array $config): array {
-  return \Drupal::service('block_plugin.view_builder')->view($bid, $config);
+  return \Drupal::service('plugin.manager.block')->createInstance($bid)->build($config);
 }
 
 /**

--- a/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing-tiny.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing-tiny.html.twig
@@ -8,6 +8,7 @@
   ] | join(' ') | trim %}
   {{ classes }}
 {% endmacro %}
+
 <div class="{{ _self.getClass(align) }}">
   {{ items }}
 </div>

--- a/web/themes/custom/server_theme/templates/server-theme-inner-element-layout--centered.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-inner-element-layout--centered.html.twig
@@ -1,7 +1,27 @@
-{% import '@server_theme/templates/server-theme-inner-element-layout-base.html.twig' as base %}
+<div class="mb-12">
+  <article class="w-full max-w-[344px] h-[312px] bg-white rounded-t-2xl p-8 flex flex-col items-center gap-10 border">
+    {{ items }}
+  </article>
 
-<div class="{{ base.getBaseClasses() }} p-4 grid place-items-center">
-
-  {{ items }}
-
+  <div class="w-[344px] h-[53px] bg-white rounded-b-2xl flex items-center border border-t-0">
+    <!-- Left half: button centered in left side -->
+    <div class="w-1/2 flex items-center justify-center">
+      <button class="p-2 hover:bg-gray-100 rounded-full flex items-center gap-2">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M2.003 5.884L10 9.882L17.997 5.884C17.9674 5.37444 17.7441 4.89549 17.3728 4.54523C17.0016 4.19497 16.5104 3.99991 16 4H4C3.48958 3.99991 2.99845 4.19497 2.62718 4.54523C2.25591 4.89549 2.0326 5.37444 2.003 5.884Z" fill="#BDBDBDFF"/>
+          <path d="M18 8.118L10 12.118L2 8.118V14C2 14.5304 2.21071 15.0391 2.58579 15.4142C2.96086 15.7893 3.46957 16 4 16H16C16.5304 16 17.0391 15.7893 17.4142 15.4142C17.7893 15.0391 18 14.5304 18 14V8.118Z" fill="#BDBDBDFF"/>
+        </svg>
+        Email
+      </button>
+    </div>
+    <div class="w-px h-10 bg-gray-200"></div>
+    <div class="w-1/2 flex items-center justify-center">
+      <button class="p-2 hover:bg-gray-100 flex items-center gap-2">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M2.00012 3C2.00012 2.44772 2.44784 2 3.00012 2H5.153C5.64183 2 6.05902 2.35341 6.13939 2.8356L6.8787 7.27147C6.95087 7.70451 6.73218 8.13397 6.33952 8.3303L4.79138 9.10437C5.90768 11.8783 8.1218 14.0924 10.8958 15.2087L11.6698 13.6606C11.8661 13.2679 12.2956 13.0492 12.7286 13.1214L17.1645 13.8607C17.6467 13.9411 18.0001 14.3583 18.0001 14.8471V17C18.0001 17.5523 17.5524 18 17.0001 18H15.0001C7.82042 18 2.00012 12.1797 2.00012 5V3Z" fill="#BDBDBDFF"/>
+        </svg>
+        <span class="text-gray-600">Call</span>
+      </button>
+    </div>
+  </div>
 </div>

--- a/web/themes/custom/server_theme/templates/server-theme-text-decoration--font-color.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-text-decoration--font-color.html.twig
@@ -6,6 +6,11 @@
   {% set color_class = 'text-gray-700' %}
 {% endif %}
 
-<div class="{{ color_class }}">
+{% set background_color_class = '' %}
+{% if backgroundColor == 'light-green' %}
+  {% set background_color_class = 'bg-green-100 text-green-800 text-xs px-2 py-1 rounded-xl' %}
+{% endif %}
+
+<div class="{% if background_color_class %} {{ background_color_class }} {% endif %} {{ color_class }}">
   {{ element }}
 </div>


### PR DESCRIPTION
feat: enable server_general and server_style_guide modules for displa…ying /style-guide page
feat: clean up the code in the StyleGuideController.php to make the route working
feat: add new StyleGuideController function to not mess the existing logic (and sometimes the functions are giving errors (test on fresh install and fix whenever possible))
feat: enable the theme, andd scripts for easily converting css
feat: fix the LanguageDropdownConstants::LANGDROPDOWN_SIMPLE_SELECT error - since it is thrown if the module is not enabled
feat: override templates to achieve the desired output